### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/app/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
@@ -31,6 +31,12 @@ import java.util.Map;
 public class HttpHeaderParser {
 
     /**
+     * Prevents class instantiation 
+     */
+    private HttpHeaderParser() {
+    }
+
+    /**
      * Extracts a {@link Cache.Entry} from a {@link NetworkResponse}.
      *
      * @param response The network response to parse headers from

--- a/app/src/main/java/com/handmark/pulltorefresh/library/OverscrollHelper.java
+++ b/app/src/main/java/com/handmark/pulltorefresh/library/OverscrollHelper.java
@@ -27,6 +27,11 @@ public final class OverscrollHelper {
 
 	static final String LOG_TAG = "OverscrollHelper";
 	static final float DEFAULT_OVERSCROLL_SCALE = 1f;
+	/**
+	 * Prevents class instantiation 
+	 */
+	private OverscrollHelper() {
+	}
 
 	/**
 	 * Helper method for Overscrolling that encapsulates all of the necessary

--- a/app/src/main/java/com/handmark/pulltorefresh/library/internal/Utils.java
+++ b/app/src/main/java/com/handmark/pulltorefresh/library/internal/Utils.java
@@ -5,6 +5,11 @@ import android.util.Log;
 public class Utils {
 
 	static final String LOG_TAG = "PullToRefresh";
+	/**
+	 * Prevents class instantiation 
+	 */
+	private Utils() {
+	}
 
 	public static void warnDeprecation(String depreacted, String replacement) {
 		Log.w(LOG_TAG, "You're using the deprecated " + depreacted + " attr, please switch over to " + replacement);

--- a/app/src/main/java/com/skooterapp/RealPathUtil.java
+++ b/app/src/main/java/com/skooterapp/RealPathUtil.java
@@ -9,6 +9,11 @@ import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 
 public class RealPathUtil {
+    /**
+     * Prevents class instantiation 
+     */
+    private RealPathUtil() {
+    }
 
     @SuppressLint("NewApi")
     public static String getRealPathFromURI_API19(Context context, Uri uri){

--- a/app/src/main/java/uk/co/senab/photoview/gestures/VersionedGestureDetector.java
+++ b/app/src/main/java/uk/co/senab/photoview/gestures/VersionedGestureDetector.java
@@ -20,6 +20,11 @@ import android.content.Context;
 import android.os.Build;
 
 public final class VersionedGestureDetector {
+    /**
+     * Prevents class instantiation 
+     */
+    private VersionedGestureDetector() {
+    }
 
     public static GestureDetector newInstance(Context context,
                                               OnGestureListener listener) {

--- a/app/src/main/java/uk/co/senab/photoview/log/LogManager.java
+++ b/app/src/main/java/uk/co/senab/photoview/log/LogManager.java
@@ -23,6 +23,11 @@ import android.util.Log;
 public final class LogManager {
 
     private static Logger logger = new LoggerDefault();
+    /**
+     * Prevents class instantiation 
+     */
+    private LogManager() {
+    }
 
     public static void setLogger(Logger newLogger) {
         logger = newLogger;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
