### PR TITLE
[squid:S2864] "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/app/src/main/java/com/android/volley/toolbox/HttpClientStack.java
+++ b/app/src/main/java/com/android/volley/toolbox/HttpClientStack.java
@@ -57,16 +57,16 @@ public class HttpClientStack implements HttpStack {
     }
 
     private static void addHeaders(HttpUriRequest httpRequest, Map<String, String> headers) {
-        for (String key : headers.keySet()) {
-            httpRequest.setHeader(key, headers.get(key));
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            httpRequest.setHeader(entry.getKey(), entry.getValue());
         }
     }
 
     @SuppressWarnings("unused")
     private static List<NameValuePair> getPostParameterPairs(Map<String, String> postParams) {
         List<NameValuePair> result = new ArrayList<NameValuePair>(postParams.size());
-        for (String key : postParams.keySet()) {
-            result.add(new BasicNameValuePair(key, postParams.get(key)));
+        for (Map.Entry<String, String> entry : postParams.entrySet()) {
+            result.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
         }
         return result;
     }

--- a/app/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/app/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -100,8 +100,8 @@ public class HurlStack implements HttpStack {
         }
         URL parsedUrl = new URL(url);
         HttpURLConnection connection = openConnection(parsedUrl, request);
-        for (String headerName : map.keySet()) {
-            connection.addRequestProperty(headerName, map.get(headerName));
+        for (Entry<String, String> entry : map.entrySet()) {
+            connection.addRequestProperty(entry.getKey(), entry.getValue());
         }
         setConnectionParametersForRequest(connection, request);
         // Initialize HttpResponse with data from the HttpURLConnection.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.
Ayman Abdelghany.
